### PR TITLE
Add volume settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ I created it to learn the basics of Python, understand its logic and syntax, and
 The project runs well, but I won’t focus on perfecting every little detail.
 Instead, I want to move on to new projects to further improve my skills.
 
+## Features
+
+- Save and load progress including game settings
+- Adjustable music and sound effect volume in the settings window
+


### PR DESCRIPTION
## Summary
- save and load new music/sound volume settings
- add sliders for volume in the settings window
- make README mention features

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68488ea654908322ac9f168e75a7c4da